### PR TITLE
Use all sass options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 module.exports = function sass ( srcDir, destDir, options, done, err ) {
-	require( 'node-sass' ).render({
-		file: require( 'path' ).resolve( srcDir, options.src ),
-		success: function ( css ) {
-			require( 'gobble' ).file.write( destDir, options.dest, css ).then( done, err );
-		},
-		error: err
-	});
+
+	if ( !options || !options.src || !options.dest ) {
+		throw new Error('gobble-sass requires options.src and options.dest to be set')
+	}
+
+	options.file = require( 'path' ).resolve( srcDir, options.src );
+	options.success = function ( css ) {
+		require( 'gobble' ).file.write( destDir, options.dest, css ).then( done, err );
+	}
+	options.err = err
+
+	require( 'node-sass' ).render( options );
 };


### PR DESCRIPTION
Looks like this API needs to be updated, but thought I'd do a PR because I needed the sass options anyway. No biggy if you don't want or are going to update API anyway and use sander.

I also created a gobble-sass-file for individual files like so:

``` js
var sass = require('node-sass');

function sassFile(input, options) {
    options = options || {}
    options.data = input
    return sass.renderSync(options)
}

sassFile.defaults = {
    accept: ['.scss'],
    ext: '.css'
}

module.exports = sassFile
```

which is useful for component css
