### PR TITLE
Update package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-sass",
   "dependencies": {
-    "node-sass": "^0.9.3",
-    "sander": "^0.1.6"
+    "node-sass": "^1.1.4",
+    "sander": "^0.2.1"
   },
   "keywords": [
     "gobble",


### PR DESCRIPTION
A ton of `node-sass` issues were fixed in the last couple of months, so it makes sense to update it to the latest stable version. There is a new `sander` version too.
