### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ module.exports = function sass ( inputdir, outputdir, options, callback ) {
 			promises.push( sander.writeFile( outputdir, options.dest + '.map', result.map ) );
 		}
 
-		sander.Promise.all( promises ).then( function () { callback(); }, callback );
+		Promise.all( promises ).then( function () { callback(); }, callback );
 	});
 };

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-sass",
   "dependencies": {
-    "node-sass": "^3.0.0",
-    "sander": "^0.3.3"
+    "node-sass": "^4.5.3",
+    "sander": "^0.6.0"
   },
   "keywords": [
     "gobble",
@@ -18,7 +18,7 @@
     "README.md"
   ],
   "devDependencies": {
-    "mocha": "^2.2.4"
+    "mocha": "^3.4.2"
   },
   "scripts": {
     "test": "mocha",

--- a/test/test.js
+++ b/test/test.js
@@ -71,7 +71,7 @@ describe( 'gobble-sass', function () {
 				sourceRoot: OUTPUT + '/a',
 				sources: [ '../../samples/a/in.scss' ],
 				sourcesContent: [ sander.readFileSync( SAMPLES, 'a/in.scss' ).toString() ],
-				mappings: 'AAGC,IAAI,CAAC,EAAE,CAAJ;EACF,KAAK,EAJD,OAAG,GAGJ',
+				mappings: 'AAEA,AACC,IADG,CACH,EAAE,CAAC;EACF,KAAK,EAJD,OAAG,GAKP',
 				names: []
 			});
 
@@ -79,7 +79,7 @@ describe( 'gobble-sass', function () {
 		});
 	});
 
-	it( 'omits sourcemap if `options.sourceMap` === false', function () {
+	it( 'omits sourcemap if `options.sourceMap` === false', function ( done ) {
 		transformer( SAMPLES + '/a', OUTPUT + '/a', {
 			src: 'in.scss',
 			dest: 'out.css',


### PR DESCRIPTION
Bump dependencies mainly for [node-sass](https://github.com/sass/node-sass) to build reliably on various Windows systems.